### PR TITLE
Add basic SQLite DAO for VideoAula

### DIFF
--- a/lib/dao/dao_video_aula.dart
+++ b/lib/dao/dao_video_aula.dart
@@ -1,0 +1,27 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import '../dto/dto_video_aula.dart';
+import 'database_connection.dart';
+
+class DaoVideoAula {
+  Future<int> inserir(VideoAulaDto video) async {
+    final db = await DatabaseConnection().database;
+    return db.insert('video_aula', video.toJson());
+  }
+
+  Future<List<VideoAulaDto>> listarTodos() async {
+    final db = await DatabaseConnection().database;
+    final maps = await db.query('video_aula');
+    return maps.map((e) => VideoAulaDto.fromJson(e)).toList();
+  }
+
+  Future<int> atualizar(VideoAulaDto video) async {
+    final db = await DatabaseConnection().database;
+    return db.update('video_aula', video.toJson(),
+        where: 'id = ?', whereArgs: [video.id]);
+  }
+
+  Future<int> excluir(int id) async {
+    final db = await DatabaseConnection().database;
+    return db.delete('video_aula', where: 'id = ?', whereArgs: [id]);
+  }
+}

--- a/lib/dao/database_connection.dart
+++ b/lib/dao/database_connection.dart
@@ -1,0 +1,36 @@
+import 'package:path/path.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class DatabaseConnection {
+  static final DatabaseConnection _instance = DatabaseConnection._internal();
+  factory DatabaseConnection() => _instance;
+  DatabaseConnection._internal();
+
+  Database? _database;
+
+  Future<Database> get database async {
+    if (_database != null) return _database!;
+    sqfliteFfiInit();
+    var databaseFactory = databaseFactoryFfi;
+    final dbPath = await databaseFactory.getDatabasesPath();
+    final path = join(dbPath, 'app.db');
+    // await deleteDatabase(path); // removed as per instructions
+    _database = await databaseFactory.openDatabase(path,
+        options: OpenDatabaseOptions(
+          version: 1,
+          onCreate: _onCreate,
+        ));
+    return _database!;
+  }
+
+  Future<void> _onCreate(Database db, int version) async {
+    await db.execute('''
+      CREATE TABLE video_aula(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        nome TEXT,
+        link_video TEXT,
+        ativo INTEGER
+      )
+    ''');
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,8 +5,11 @@ import 'package:flutter_application_1/telas/form_sala.dart';
 import 'package:flutter_application_1/telas/form_tipo_manutencao.dart';
 import 'package:flutter_application_1/telas/form_video_aula.dart';
 import 'package:flutter_application_1/telas/tela_dashboard.dart';
+import 'package:flutter_application_1/dao/database_connection.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await DatabaseConnection().database;
   runApp(const MyApp());
 }
 

--- a/lib/telas/form_video_aula.dart
+++ b/lib/telas/form_video_aula.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_application_1/dto/dto_video_aula.dart';
-import 'package:flutter_application_1/dto/dto_video_aula.dart';
+import 'package:flutter_application_1/dao/dao_video_aula.dart';
 
 class FormVideoAula extends StatefulWidget {
   const FormVideoAula({Key? key}) : super(key: key);
@@ -20,6 +20,7 @@ class _FormVideoAulaState extends State<FormVideoAula> {
 
   // DTO para armazenar o resultado
   VideoAulaDto? videoAulaDto;
+  final DaoVideoAula _dao = DaoVideoAula();
 
   @override
   Widget build(BuildContext context) {
@@ -112,12 +113,7 @@ class _FormVideoAulaState extends State<FormVideoAula> {
         ativo: ativo,
       );
 
-      // Exemplo: DTO pronto para uso
-      debugPrint('VideoAulaDto gerado:');
-      debugPrint(videoAulaDto!.toJson().toString());
-
-      // Exemplo: poderia chamar um service aqui
-      // await VideoAulaService.salvar(videoAulaDto!);
+        _dao.inserir(videoAulaDto!);
 
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Vídeo Aula salva com sucesso!')),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,11 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  sqflite: any
+  path: any
+  sqflite_common_ffi: any
+  sqflite_common_ffi_web: any
+  mask_text_input_formatter: any
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add SQLite deps
- bootstrap the database on startup and create a VideoAula table
- add DAO with CRUD helpers for video aulas
- integrate the DAO in the video aula form

## Testing
- `dart format lib/dao lib/telas lib/main.dart pubspec.yaml` *(fails: `dart: command not found`)*
- `dart run sqflite_common_ffi_web:setup` *(fails: `dart: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_685dd2151c54832ebfad9c9a9a469b9c